### PR TITLE
Fix warning in draft-ERC20PermitUpgradeable.sol

### DIFF
--- a/contracts/mocks/ERC20PermitMockUpgradeable.sol
+++ b/contracts/mocks/ERC20PermitMockUpgradeable.sol
@@ -15,7 +15,7 @@ contract ERC20PermitMockUpgradeable is Initializable, ERC20PermitUpgradeable {
         __Context_init_unchained();
         __ERC20_init_unchained(name, symbol);
         __EIP712_init_unchained(name, "1");
-        __ERC20Permit_init_unchained(name);
+        __ERC20Permit_init_unchained();
         __ERC20PermitMock_init_unchained(name, symbol, initialAccount, initialBalance);
     }
 

--- a/contracts/mocks/ERC20VotesCompMockUpgradeable.sol
+++ b/contracts/mocks/ERC20VotesCompMockUpgradeable.sol
@@ -10,7 +10,7 @@ contract ERC20VotesCompMockUpgradeable is Initializable, ERC20VotesCompUpgradeab
         __Context_init_unchained();
         __ERC20_init_unchained(name, symbol);
         __EIP712_init_unchained(name, "1");
-        __ERC20Permit_init_unchained(name);
+        __ERC20Permit_init_unchained();
         __ERC20Votes_init_unchained();
         __ERC20VotesComp_init_unchained();
         __ERC20VotesCompMock_init_unchained(name, symbol);

--- a/contracts/mocks/ERC20VotesMockUpgradeable.sol
+++ b/contracts/mocks/ERC20VotesMockUpgradeable.sol
@@ -10,7 +10,7 @@ contract ERC20VotesMockUpgradeable is Initializable, ERC20VotesUpgradeable {
         __Context_init_unchained();
         __ERC20_init_unchained(name, symbol);
         __EIP712_init_unchained(name, "1");
-        __ERC20Permit_init_unchained(name);
+        __ERC20Permit_init_unchained();
         __ERC20Votes_init_unchained();
         __ERC20VotesMock_init_unchained(name, symbol);
     }

--- a/contracts/token/ERC20/extensions/draft-ERC20PermitUpgradeable.sol
+++ b/contracts/token/ERC20/extensions/draft-ERC20PermitUpgradeable.sol
@@ -35,10 +35,10 @@ abstract contract ERC20PermitUpgradeable is Initializable, ERC20Upgradeable, IER
     function __ERC20Permit_init(string memory name) internal initializer {
         __Context_init_unchained();
         __EIP712_init_unchained(name, "1");
-        __ERC20Permit_init_unchained(name);
+        __ERC20Permit_init_unchained();
     }
 
-    function __ERC20Permit_init_unchained(string memory name) internal initializer {
+    function __ERC20Permit_init_unchained() internal initializer {
         _PERMIT_TYPEHASH = keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");}
 
     /**


### PR DESCRIPTION
Fix warning:
```
Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
  --> @openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-ERC20PermitUpgradeable.sol:41:43:
   |
41 |     function __ERC20Permit_init_unchained(string memory name) internal initializer {
   |                                           ^^^^^^^^^^^^^^^^^^
```