### PR TITLE
use ERC20PermitMockUpgradeable instead

### DIFF
--- a/test/token/ERC20/extensions/draft-ERC20Permit.test.js
+++ b/test/token/ERC20/extensions/draft-ERC20Permit.test.js
@@ -8,7 +8,7 @@ const { fromRpcSig } = require('ethereumjs-util');
 const ethSigUtil = require('eth-sig-util');
 const Wallet = require('ethereumjs-wallet').default;
 
-const ERC20PermitMock = artifacts.require('ERC20PermitMock');
+const ERC20PermitMock = artifacts.require('ERC20PermitMockUpgradeable');
 
 const { EIP712Domain, domainSeparator } = require('../../../helpers/eip712');
 


### PR DESCRIPTION
use ERC20PermitMockUpgradeable instead of ERC20PermitMock in ERC20Permit test