### PR TITLE
Fix typo in doc of SignatureCheckerUpgradeable

### DIFF
--- a/contracts/utils/cryptography/SignatureCheckerUpgradeable.sol
+++ b/contracts/utils/cryptography/SignatureCheckerUpgradeable.sol
@@ -8,7 +8,7 @@ import "../../interfaces/IERC1271Upgradeable.sol";
 
 /**
  * @dev Signature verification helper: Provide a single mechanism to verify both private-key (EOA) ECDSA signature and
- * ERC1271 contract sigantures. Using this instead of ECDSA.recover in your contract will make them compatible with
+ * ERC1271 contract signatures. Using this instead of ECDSA.recover in your contract will make them compatible with
  * smart contract wallets such as Argent and Gnosis.
  *
  * Note: unlike ECDSA signatures, contract signature's are revocable, and the outcome of this function can thus change


### PR DESCRIPTION
Fix typo in doc of `SignatureCheckerUpgradeable`:
```diff
- sigantures
+ signatures
```

#### PR Checklist

- [ ] ~~Tests~~
- [x] Documentation
- [ ] ~~Changelog entry~~