### PR TITLE
feat: add upgradeInit to initializable

### DIFF
--- a/contracts/mocks/InitializableMock.sol
+++ b/contracts/mocks/InitializableMock.sol
@@ -11,9 +11,14 @@ import "../proxy/utils/Initializable.sol";
 contract InitializableMock is Initializable {
     bool public initializerRan;
     uint256 public x;
+    bool public upgradeRan;
 
     function initialize() public initializer {
         initializerRan = true;
+    }
+
+    function upgrade() public upgradeInit(1) {
+        upgradeRan = true;
     }
 
     function initializeNested() public initializer {

--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -31,9 +31,9 @@ pragma solidity ^0.8.0;
  */
 abstract contract Initializable {
     /**
-     * @dev Indicates that the contract has been initialized.
+     * @dev Indicates that the contract has been initialized to this level.
      */
-    bool private _initialized;
+    uint256 private _upgradeLevel;
 
     /**
      * @dev Indicates that the contract is in the process of being initialized.
@@ -44,18 +44,35 @@ abstract contract Initializable {
      * @dev Modifier to protect an initializer function from being invoked twice.
      */
     modifier initializer() {
-        require(_initializing || !_initialized, "Initializable: contract is already initialized");
-
-        bool isTopLevelCall = !_initializing;
-        if (isTopLevelCall) {
-            _initializing = true;
-            _initialized = true;
-        }
-
+        bool isTopLevelCall = _preInitialize(0);
         _;
-
         if (isTopLevelCall) {
             _initializing = false;
         }
+    }
+
+    /**
+     * @dev Modifier to protect an initializer function from being invoked twice.
+     */
+    modifier upgradeInit(uint256 upgradeLevel) {
+        bool isTopLevelCall = _preInitialize(upgradeLevel);
+        _;
+        if (isTopLevelCall) {
+            _initializing = false;
+        }
+    }
+
+    function _preInitialize(uint256 upgradeLevel) private returns(bool) {
+        require(_initializing || _upgradeLevel <= upgradeLevel, "Initializable: contract is already initialized");
+        if (!_initializing) {
+            _initializing = true;
+            _upgradeLevel = _upgradeLevel + 1;
+            return true;
+        }
+        return false;
+    }
+
+    function getUpgradeLevel() public view returns(uint256) {
+        return _upgradeLevel;
     }
 }

--- a/test/proxy/utils/Initializable.test.js
+++ b/test/proxy/utils/Initializable.test.js
@@ -1,4 +1,4 @@
-const { expectRevert } = require('@openzeppelin/test-helpers');
+const { expectRevert, BN } = require('@openzeppelin/test-helpers');
 
 const { assert } = require('chai');
 
@@ -38,6 +38,39 @@ contract('Initializable', function (accounts) {
 
       it('initializer has run', async function () {
         assert.isTrue(await this.contract.initializerRan());
+      });
+    });
+  });
+
+  describe('basic upgrade testing', function () {
+    beforeEach('deploying', async function () {
+      this.contract = await InitializableMock.new();
+    });
+
+    context('before initialize', function () {
+      it('initializer has not run', async function () {
+        assert.isFalse(await this.contract.initializerRan());
+        assert.isFalse(await this.contract.upgradeRan());
+      });
+    });
+
+    context('after initialize and upgrade', function () {
+      beforeEach('initializing', async function () {
+        await this.contract.initialize();
+        await this.contract.upgrade();
+      });
+
+      it('initializer and upgrade has run', async function () {
+        assert.isTrue(await this.contract.initializerRan());
+        assert.isTrue(await this.contract.upgradeRan());
+      });
+
+      it('initializer does not run again', async function () {
+        await expectRevert(this.contract.initialize(), 'Initializable: contract is already initialized');
+      });
+
+      it('upgrade does not run again', async function () {
+        await expectRevert(this.contract.upgrade(), 'Initializable: contract is already initialized');
       });
     });
   });


### PR DESCRIPTION
This is a Draft PR: Add the posibility to reuse initializable for upgrades.

- [x] Tests
- [ ] Documentation
- [ ] Changelog entry
