### PR TITLE
fix: Transpilation error in ECDSAUpgradeable is causing tests to fail

### DIFF
--- a/contracts/utils/cryptography/ECDSAUpgradeable.sol
+++ b/contracts/utils/cryptography/ECDSAUpgradeable.sol
@@ -216,7 +216,7 @@ library ECDSAUpgradeable {
      * See {recover}.
      */
     function toEthSignedMessageHash(bytes memory s) internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n", StrStringsUpgradeableString(s.length), s));
+        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n", StringsUpgradeable.toString(s.length), s));
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #130 <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->
This change fixes the error raised by the unidentified `StrStringsUpgradeableString` call in [ECDSAUpgradeable.sol](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/master/contracts/utils/cryptography/ECDSAUpgradeable.sol#L219). For some reason, the transpiler is producing that call even though the OZ library has `StringsUpgradeable.toString()` (see [here](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/ECDSA.sol#L219)).

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changelog entry
