### PR TITLE
Making 2771 use init instead of constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-
+ * `ERC2771Context`: removed `constructor(address)` and reverted to using `__ERC2771Context_init(address)` and `__ERC2771Context_init_unchained(address)`.
  * `AccessControl`: add a virtual `_checkRole(bytes32)` function that can be overridden to alter the `onlyRole` modifier behavior. ([#3137](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3137))
  * `EnumerableMap`: add new `AddressToUintMap` map type. ([#3150](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3150))
  * `ERC1155`: Add a `_afterTokenTransfer` hook for improved extensibility. ([#3166](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3166))

--- a/contracts/metatx/ERC2771ContextUpgradeable.sol
+++ b/contracts/metatx/ERC2771ContextUpgradeable.sol
@@ -10,11 +10,14 @@ import "../proxy/utils/Initializable.sol";
  * @dev Context variant with ERC2771 support.
  */
 abstract contract ERC2771ContextUpgradeable is Initializable, ContextUpgradeable {
-    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
-    address private immutable _trustedForwarder;
+    address private _trustedForwarder;
 
-    /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address trustedForwarder) {
+    function __ERC2771Context_init(address trustedForwarder) internal onlyInitializing {
+        __Context_init_unchained();
+        __ERC2771Context_init_unchained(trustedForwarder);
+    }
+
+    function __ERC2771Context_init_unchained(address trustedForwarder) internal onlyInitializing {
         _trustedForwarder = trustedForwarder;
     }
 

--- a/contracts/mocks/ERC2771ContextMockUpgradeable.sol
+++ b/contracts/mocks/ERC2771ContextMockUpgradeable.sol
@@ -13,6 +13,10 @@ contract ERC2771ContextMockUpgradeable is Initializable, ContextMockUpgradeable,
         __ContextMock_init_unchained();
         __ERC2771ContextMock_init_unchained(trustedForwarder);
     }
+    
+    function __ERC2771ContextMock_init_unchained(address trustedForwarder) internal onlyInitializing {
+        emit Sender(_msgSender()); // _msgSender() should be accessible during construction
+    }
 
     function _msgSender() internal view virtual override(ContextUpgradeable, ERC2771ContextUpgradeable) returns (address) {
         return ERC2771ContextUpgradeable._msgSender();

--- a/contracts/mocks/ERC2771ContextMockUpgradeable.sol
+++ b/contracts/mocks/ERC2771ContextMockUpgradeable.sol
@@ -8,9 +8,10 @@ import "../proxy/utils/Initializable.sol";
 
 // By inheriting from ERC2771Context, Context's internal functions are overridden automatically
 contract ERC2771ContextMockUpgradeable is Initializable, ContextMockUpgradeable, ERC2771ContextUpgradeable {
-    /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address trustedForwarder) ERC2771ContextUpgradeable(trustedForwarder) {
-        emit Sender(_msgSender()); // _msgSender() should be accessible during construction
+    function __ERC2771ContextMock_init(address trustedForwarder) internal onlyInitializing {
+        __Context_init_unchained();
+        __ContextMock_init_unchained();
+        __ERC2771ContextMock_init_unchained(trustedForwarder);
     }
 
     function _msgSender() internal view virtual override(ContextUpgradeable, ERC2771ContextUpgradeable) returns (address) {


### PR DESCRIPTION
* Making 2771 use init  instead of constructor
* Update CHANGELOG.md

This broke in this commit https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/commit/2924ea3bd7536ba39fed61374c5bb2bf67207452

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
