### PR TITLE
Fixes comment & example typos

### DIFF
--- a/contracts/utils/structs/EnumerableSetUpgradeable.sol
+++ b/contracts/utils/structs/EnumerableSetUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts (last updated v4.6.0) (utils/structs/EnumerableSet.sol)
+// OpenZeppelin Contracts (last updated v4.6.0) (utils/structs/EnumerableSetUpgradeable.sol)
 
 pragma solidity ^0.8.0;
 
@@ -17,10 +17,10 @@ pragma solidity ^0.8.0;
  * ```
  * contract Example {
  *     // Add the library methods
- *     using EnumerableSet for EnumerableSet.AddressSet;
+ *     using EnumerableSetUpgradeable for EnumerableSetUpgradeable.AddressSet;
  *
  *     // Declare a set state variable
- *     EnumerableSet.AddressSet private mySet;
+ *     EnumerableSetUpgradeable.AddressSet private mySet;
  * }
  * ```
  *
@@ -32,7 +32,7 @@ pragma solidity ^0.8.0;
  *  Trying to delete such a structure from storage will likely result in data corruption, rendering the structure unusable.
  *  See https://github.com/ethereum/solidity/pull/11843[ethereum/solidity#11843] for more info.
  *
- *  In order to clean an EnumerableSet, you can either remove all elements one by one or create a fresh instance using an array of EnumerableSet.
+ *  In order to clean an EnumerableSetUpgradeable, you can either remove all elements one by one or create a fresh instance using an array of EnumerableSetUpgradeable.
  * ====
  */
 library EnumerableSetUpgradeable {
@@ -42,7 +42,7 @@ library EnumerableSetUpgradeable {
     // The Set implementation uses private functions, and user-facing
     // implementations (such as AddressSet) are just wrappers around the
     // underlying Set.
-    // This means that we can only create new EnumerableSets for types that fit
+    // This means that we can only create new EnumerableSetUpgradeable for types that fit
     // in bytes32.
 
     struct Set {


### PR DESCRIPTION
Some parts of this file referred to `EnumerableSet` when they should refer to `EnumerableSetUpgradeable`. Typo in the `Example` contract tripped me up, which is how I identified these issues.

No reference issue, just a quick typo fix.

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

<!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
