### PR TITLE
introduce storage gap to 'Initializable' contract

### DIFF
--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -135,4 +135,11 @@ abstract contract Initializable {
             emit Initialized(type(uint8).max);
         }
     }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
+    uint256[49] private __gap;
 }


### PR DESCRIPTION
In keeping with the other contracts in this repository, the 'Initializable' contract should have a storage gap of length 49, to reflect the single storage slot currently taken by the two defined variables.
Without this storage gap, future changes to the 'Initializable' contract may cause shifts in storage slots for variables defined downstream in the inheritance pattern.
I note as well that 'Initializable' should properly be named 'InitializableUpgradeable', although changing this would touch more files.
