### PR TITLE
perf: save one ISZERO in _disableInitializers

### DIFF
--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -143,7 +143,7 @@ abstract contract Initializable {
      */
     function _disableInitializers() internal virtual {
         require(!_initializing, "Initializable: contract is initializing");
-        if (_initialized < type(uint8).max) {
+        if (_initialized != type(uint8).max) {
             _initialized = type(uint8).max;
             emit Initialized(type(uint8).max);
         }


### PR DESCRIPTION
Minor optimization (2 gas) of `_disableInitializers` in `Initializable`.

A `JUMP` should happen if the condition is false. With `!=` it requires only `EQ` (3 gas) while with `<` it requires `LT` + `IZERO` (3 + 2 gas).

#### PR Checklist

- [x] Tests
- [x] Documentation
- [ ] Changelog entry
