### PR TITLE
Use `functionDelegateCall` from the `Address` library, in conjuction with `allow-recheable delegatecall`

### DIFF
--- a/contracts/mocks/AddressImpl.sol
+++ b/contracts/mocks/AddressImpl.sol
@@ -36,6 +36,11 @@ contract AddressImpl {
         emit CallReturnValue(abi.decode(returnData, (string)));
     }
 
+    function functionDelegateCall(address target, bytes calldata data) external {
+        bytes memory returnData = Address.functionDelegateCall(target, data);
+        emit CallReturnValue(abi.decode(returnData, (string)));
+    }
+
     // sendValue's tests require the contract to hold Ether
     receive() external payable {}
 }

--- a/contracts/proxy/ERC1967/ERC1967Upgrade.sol
+++ b/contracts/proxy/ERC1967/ERC1967Upgrade.sol
@@ -69,7 +69,7 @@ abstract contract ERC1967Upgrade {
     ) internal {
         _upgradeTo(newImplementation);
         if (data.length > 0 || forceCall) {
-            _functionDelegateCall(newImplementation, data);
+            Address.functionDelegateCall(newImplementation, data);
         }
     }
 
@@ -179,21 +179,7 @@ abstract contract ERC1967Upgrade {
         _setBeacon(newBeacon);
         emit BeaconUpgraded(newBeacon);
         if (data.length > 0 || forceCall) {
-            _functionDelegateCall(IBeacon(newBeacon).implementation(), data);
+            Address.functionDelegateCall(IBeacon(newBeacon).implementation(), data);
         }
-    }
-
-    /**
-     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
-     * but performing a delegate call.
-     *
-     * _Available since v3.4._
-     */
-    function _functionDelegateCall(address target, bytes memory data) private returns (bytes memory) {
-        require(Address.isContract(target), "Address: delegate call to non-contract");
-
-        // solhint-disable-next-line avoid-low-level-calls
-        (bool success, bytes memory returndata) = target.delegatecall(data);
-        return Address.verifyCallResult(success, returndata, "Address: low-level delegate call failed");
     }
 }

--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -178,11 +178,8 @@ library Address {
      * _Available since v3.4._
      */
     function functionDelegateCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
-        require(isContract(target), "Address: delegate call to non-contract");
-
-        // solhint-disable-next-line avoid-low-level-calls
         (bool success, bytes memory returndata) = target.delegatecall(data);
-        return _verifyCallResult(success, returndata, errorMessage);
+        return verifyCallResultFromTarget(target, success, returndata, errorMessage);
     }
 
     /**

--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -162,6 +162,30 @@ library Address {
     }
 
     /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(address target, bytes memory data) internal returns (bytes memory) {
+        return functionDelegateCall(target, data, "Address: low-level delegate call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        require(isContract(target), "Address: delegate call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.delegatecall(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
      * @dev Tool to verify that a low level call to smart-contract was successful, and revert (either by bubbling
      * the revert reason or using the provided one) in case of unsuccessful call or if target was not a contract.
      *

--- a/contracts/utils/Multicall.sol
+++ b/contracts/utils/Multicall.sol
@@ -17,22 +17,8 @@ abstract contract Multicall {
     function multicall(bytes[] calldata data) external virtual returns (bytes[] memory results) {
         results = new bytes[](data.length);
         for (uint256 i = 0; i < data.length; i++) {
-            results[i] = _functionDelegateCall(address(this), data[i]);
+            results[i] = Address.functionDelegateCall(address(this), data[i]);
         }
         return results;
-    }
-
-    /**
-     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
-     * but performing a delegate call.
-     *
-     * _Available since v3.4._
-     */
-    function _functionDelegateCall(address target, bytes memory data) private returns (bytes memory) {
-        require(Address.isContract(target), "Address: delegate call to non-contract");
-
-        // solhint-disable-next-line avoid-low-level-calls
-        (bool success, bytes memory returndata) = target.delegatecall(data);
-        return Address.verifyCallResult(success, returndata, "Address: low-level delegate call failed");
     }
 }


### PR DESCRIPTION
Now that the upgrade plugins is more precise in its checks, the vanilla contracts are to better target which operations are safe.

See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3971

Consequently, the upgradeable contracts can use the Address library again, and don't need to inline their own private version of `functionDelegateCall`

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
