### PR TITLE
Gas optimization

### DIFF
--- a/contracts/token/ERC777/ERC777Upgradeable.sol
+++ b/contracts/token/ERC777/ERC777Upgradeable.sol
@@ -352,7 +352,9 @@ contract ERC777Upgradeable is Initializable, ContextUpgradeable, IERC777Upgradea
 
         // Update state variables
         _totalSupply += amount;
-        _balances[account] += amount;
+        unchecked {
+            _balances[account] += amount;
+        }
 
         _callTokensReceived(operator, address(0), account, amount, userData, operatorData, requireReceptionAck);
 


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

For two numbers a and b, if a is always larger than or equal to b, unchecking addition operations on b or subtraction operations on a can save some gases.
Each item in _balances is smaller than _totalSupply. So unchecking addition operations on items in _balances can save some gases.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
