### PR TITLE
fix storage gap for `EIP712Upgradeable`

### DIFF
--- a/contracts/utils/cryptography/EIP712Upgradeable.sol
+++ b/contracts/utils/cryptography/EIP712Upgradeable.sol
@@ -117,5 +117,5 @@ abstract contract EIP712Upgradeable is Initializable {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[50] private __gap;
+    uint256[48] private __gap;
 }


### PR DESCRIPTION
Actually this PR is addressing inconsistency, not a bug.

Adjusts the gap in the `EIP712Upgradeable` contract to reserve storage for up to 50. 

The variables `_HASHED_NAME` and `_HASHED_VERSION` use a total of 2 storage slots. To reserve storage for 50 slots like other Upgradeable contracts, the gap should be reduced to 48.

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->



#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [x] Changeset entry (run `npx changeset add`)
