### PR TITLE
change memory to calldata

### DIFF
--- a/contracts/governance/GovernorUpgradeable.sol
+++ b/contracts/governance/GovernorUpgradeable.sol
@@ -140,8 +140,8 @@ abstract contract GovernorUpgradeable is Initializable, ContextUpgradeable, ERC1
      * governor) the proposer will have to change the description in order to avoid proposal id conflicts.
      */
     function hashProposal(
-        address[] memory targets,
-        uint256[] memory values,
+        address[] calldata targets,
+        uint256[] calldata values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
     ) public pure virtual override returns (uint256) {
@@ -252,10 +252,10 @@ abstract contract GovernorUpgradeable is Initializable, ContextUpgradeable, ERC1
      * @dev See {IGovernor-propose}.
      */
     function propose(
-        address[] memory targets,
-        uint256[] memory values,
+        address[] calldata targets,
+        uint256[] calldata values,
         bytes[] memory calldatas,
-        string memory description
+        string calldata description
     ) public virtual override returns (uint256) {
         address proposer = _msgSender();
 
@@ -299,8 +299,8 @@ abstract contract GovernorUpgradeable is Initializable, ContextUpgradeable, ERC1
      * @dev See {IGovernor-execute}.
      */
     function execute(
-        address[] memory targets,
-        uint256[] memory values,
+        address[] calldata targets,
+        uint256[] calldata values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
     ) public payable virtual override returns (uint256) {
@@ -391,8 +391,8 @@ abstract contract GovernorUpgradeable is Initializable, ContextUpgradeable, ERC1
      * Emits a {IGovernor-ProposalCanceled} event.
      */
     function _cancel(
-        address[] memory targets,
-        uint256[] memory values,
+        address[] calldata targets,
+        uint256[] calldata values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
     ) internal virtual returns (uint256) {
@@ -432,7 +432,7 @@ abstract contract GovernorUpgradeable is Initializable, ContextUpgradeable, ERC1
     function getVotesWithParams(
         address account,
         uint256 blockNumber,
-        bytes memory params
+        bytes calldata params
     ) public view virtual override returns (uint256) {
         return _getVotes(account, blockNumber, params);
     }
@@ -464,7 +464,7 @@ abstract contract GovernorUpgradeable is Initializable, ContextUpgradeable, ERC1
         uint256 proposalId,
         uint8 support,
         string calldata reason,
-        bytes memory params
+        bytes calldata params
     ) public virtual override returns (uint256) {
         address voter = _msgSender();
         return _castVote(proposalId, voter, support, reason, params);
@@ -496,7 +496,7 @@ abstract contract GovernorUpgradeable is Initializable, ContextUpgradeable, ERC1
         uint256 proposalId,
         uint8 support,
         string calldata reason,
-        bytes memory params,
+        bytes calldata params,
         uint8 v,
         bytes32 r,
         bytes32 s
@@ -586,7 +586,7 @@ abstract contract GovernorUpgradeable is Initializable, ContextUpgradeable, ERC1
     /**
      * @dev See {IERC721Receiver-onERC721Received}.
      */
-    function onERC721Received(address, address, uint256, bytes memory) public virtual override returns (bytes4) {
+    function onERC721Received(address, address, uint256, bytes calldata) public virtual override returns (bytes4) {
         return this.onERC721Received.selector;
     }
 
@@ -598,7 +598,7 @@ abstract contract GovernorUpgradeable is Initializable, ContextUpgradeable, ERC1
         address,
         uint256,
         uint256,
-        bytes memory
+        bytes calldata
     ) public virtual override returns (bytes4) {
         return this.onERC1155Received.selector;
     }
@@ -609,9 +609,9 @@ abstract contract GovernorUpgradeable is Initializable, ContextUpgradeable, ERC1
     function onERC1155BatchReceived(
         address,
         address,
-        uint256[] memory,
-        uint256[] memory,
-        bytes memory
+        uint256[] calldata,
+        uint256[] calldata,
+        bytes calldata
     ) public virtual override returns (bytes4) {
         return this.onERC1155BatchReceived.selector;
     }

--- a/contracts/governance/IGovernorUpgradeable.sol
+++ b/contracts/governance/IGovernorUpgradeable.sol
@@ -117,8 +117,8 @@ abstract contract IGovernorUpgradeable is Initializable, IERC165Upgradeable {
      * @dev Hashing function used to (re)build the proposal id from the proposal details..
      */
     function hashProposal(
-        address[] memory targets,
-        uint256[] memory values,
+        address[] calldata targets,
+        uint256[] calldata values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
     ) public pure virtual returns (uint256);
@@ -201,10 +201,10 @@ abstract contract IGovernorUpgradeable is Initializable, IERC165Upgradeable {
      * Emits a {ProposalCreated} event.
      */
     function propose(
-        address[] memory targets,
-        uint256[] memory values,
+        address[] calldata targets,
+        uint256[] calldata values,
         bytes[] memory calldatas,
-        string memory description
+        string calldata description
     ) public virtual returns (uint256 proposalId);
 
     /**

--- a/contracts/governance/TimelockControllerUpgradeable.sol
+++ b/contracts/governance/TimelockControllerUpgradeable.sol
@@ -396,7 +396,7 @@ contract TimelockControllerUpgradeable is Initializable, AccessControlUpgradeabl
     /**
      * @dev See {IERC721Receiver-onERC721Received}.
      */
-    function onERC721Received(address, address, uint256, bytes memory) public virtual override returns (bytes4) {
+    function onERC721Received(address, address, uint256, bytes calldata) public virtual override returns (bytes4) {
         return this.onERC721Received.selector;
     }
 
@@ -408,7 +408,7 @@ contract TimelockControllerUpgradeable is Initializable, AccessControlUpgradeabl
         address,
         uint256,
         uint256,
-        bytes memory
+        bytes calldata
     ) public virtual override returns (bytes4) {
         return this.onERC1155Received.selector;
     }
@@ -419,9 +419,9 @@ contract TimelockControllerUpgradeable is Initializable, AccessControlUpgradeabl
     function onERC1155BatchReceived(
         address,
         address,
-        uint256[] memory,
-        uint256[] memory,
-        bytes memory
+        uint256[] calldata,
+        uint256[] calldata,
+        bytes calldata
     ) public virtual override returns (bytes4) {
         return this.onERC1155BatchReceived.selector;
     }

--- a/contracts/governance/compatibility/GovernorCompatibilityBravoUpgradeable.sol
+++ b/contracts/governance/compatibility/GovernorCompatibilityBravoUpgradeable.sol
@@ -56,10 +56,10 @@ abstract contract GovernorCompatibilityBravoUpgradeable is Initializable, IGover
      * @dev See {IGovernor-propose}.
      */
     function propose(
-        address[] memory targets,
-        uint256[] memory values,
+        address[] calldata targets,
+        uint256[] calldata values,
         bytes[] memory calldatas,
-        string memory description
+        string calldata description
     ) public virtual override(IGovernorUpgradeable, GovernorUpgradeable) returns (uint256) {
         _storeProposal(_msgSender(), targets, values, new string[](calldatas.length), calldatas, description);
         return super.propose(targets, values, calldatas, description);
@@ -69,11 +69,11 @@ abstract contract GovernorCompatibilityBravoUpgradeable is Initializable, IGover
      * @dev See {IGovernorCompatibilityBravo-propose}.
      */
     function propose(
-        address[] memory targets,
-        uint256[] memory values,
-        string[] memory signatures,
-        bytes[] memory calldatas,
-        string memory description
+        address[] calldata targets,
+        uint256[] calldata values,
+        string[] calldata signatures,
+        bytes[] calldata calldatas,
+        string calldata description
     ) public virtual override returns (uint256) {
         _storeProposal(_msgSender(), targets, values, signatures, calldatas, description);
         return propose(targets, values, _encodeCalldata(signatures, calldatas), description);
@@ -139,11 +139,11 @@ abstract contract GovernorCompatibilityBravoUpgradeable is Initializable, IGover
      */
     function _storeProposal(
         address proposer,
-        address[] memory targets,
-        uint256[] memory values,
+        address[] calldata targets,
+        uint256[] calldata values,
         string[] memory signatures,
         bytes[] memory calldatas,
-        string memory description
+        string calldata description
     ) private {
         bytes32 descriptionHash = keccak256(bytes(description));
         uint256 proposalId = hashProposal(targets, values, _encodeCalldata(signatures, calldatas), descriptionHash);

--- a/contracts/governance/extensions/GovernorProposalThresholdUpgradeable.sol
+++ b/contracts/governance/extensions/GovernorProposalThresholdUpgradeable.sol
@@ -19,10 +19,10 @@ abstract contract GovernorProposalThresholdUpgradeable is Initializable, Governo
     function __GovernorProposalThreshold_init_unchained() internal onlyInitializing {
     }
     function propose(
-        address[] memory targets,
-        uint256[] memory values,
+        address[] calldata targets,
+        uint256[] calldata values,
         bytes[] memory calldatas,
-        string memory description
+        string calldata description
     ) public virtual override returns (uint256) {
         return super.propose(targets, values, calldatas, description);
     }

--- a/contracts/governance/extensions/GovernorTimelockCompoundUpgradeable.sol
+++ b/contracts/governance/extensions/GovernorTimelockCompoundUpgradeable.sol
@@ -94,8 +94,8 @@ abstract contract GovernorTimelockCompoundUpgradeable is Initializable, IGoverno
      * @dev Function to queue a proposal to the timelock.
      */
     function queue(
-        address[] memory targets,
-        uint256[] memory values,
+        address[] calldata targets,
+        uint256[] calldata values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
     ) public virtual override returns (uint256) {
@@ -141,8 +141,8 @@ abstract contract GovernorTimelockCompoundUpgradeable is Initializable, IGoverno
      * been queued.
      */
     function _cancel(
-        address[] memory targets,
-        uint256[] memory values,
+        address[] calldata targets,
+        uint256[] calldata values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
     ) internal virtual override returns (uint256) {

--- a/contracts/mocks/ContextMockUpgradeable.sol
+++ b/contracts/mocks/ContextMockUpgradeable.sol
@@ -19,7 +19,7 @@ contract ContextMockUpgradeable is Initializable, ContextUpgradeable {
 
     event Data(bytes data, uint256 integerValue, string stringValue);
 
-    function msgData(uint256 integerValue, string memory stringValue) public {
+    function msgData(uint256 integerValue, string calldata stringValue) public {
         emit Data(_msgData(), integerValue, stringValue);
     }
 
@@ -41,7 +41,7 @@ contract ContextMockCallerUpgradeable is Initializable {
         context.msgSender();
     }
 
-    function callData(ContextMockUpgradeable context, uint256 integerValue, string memory stringValue) public {
+    function callData(ContextMockUpgradeable context, uint256 integerValue, string calldata stringValue) public {
         context.msgData(integerValue, stringValue);
     }
 

--- a/contracts/mocks/EIP712VerifierUpgradeable.sol
+++ b/contracts/mocks/EIP712VerifierUpgradeable.sol
@@ -12,7 +12,7 @@ abstract contract EIP712VerifierUpgradeable is Initializable, EIP712Upgradeable 
 
     function __EIP712Verifier_init_unchained() internal onlyInitializing {
     }
-    function verify(bytes memory signature, address signer, address mailTo, string memory mailContents) external view {
+    function verify(bytes calldata signature, address signer, address mailTo, string calldata mailContents) external view {
         bytes32 digest = _hashTypedDataV4(
             keccak256(abi.encode(keccak256("Mail(address to,string contents)"), mailTo, keccak256(bytes(mailContents))))
         );

--- a/contracts/mocks/ERC1271WalletMockUpgradeable.sol
+++ b/contracts/mocks/ERC1271WalletMockUpgradeable.sol
@@ -17,7 +17,7 @@ contract ERC1271WalletMockUpgradeable is Initializable, OwnableUpgradeable, IERC
         transferOwnership(originalOwner);
     }
 
-    function isValidSignature(bytes32 hash, bytes memory signature) public view override returns (bytes4 magicValue) {
+    function isValidSignature(bytes32 hash, bytes calldata signature) public view override returns (bytes4 magicValue) {
         return ECDSAUpgradeable.recover(hash, signature) == owner() ? this.isValidSignature.selector : bytes4(0);
     }
 
@@ -35,7 +35,7 @@ contract ERC1271MaliciousMockUpgradeable is Initializable, IERC1271Upgradeable {
 
     function __ERC1271MaliciousMock_init_unchained() internal onlyInitializing {
     }
-    function isValidSignature(bytes32, bytes memory) public pure override returns (bytes4) {
+    function isValidSignature(bytes32, bytes calldata) public pure override returns (bytes4) {
         assembly {
             mstore(0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
             return(0, 32)

--- a/contracts/mocks/MultipleInheritanceInitializableMocks.sol
+++ b/contracts/mocks/MultipleInheritanceInitializableMocks.sol
@@ -108,7 +108,7 @@ contract SampleFather is Initializable, SampleGramps {
 contract SampleChild is Initializable, SampleMother, SampleFather {
     uint256 public child;
 
-    function initialize(uint256 _mother, string memory _gramps, uint256 _father, uint256 _child) public initializer {
+    function initialize(uint256 _mother, string calldata _gramps, uint256 _father, uint256 _child) public initializer {
         __SampleChild_init(_mother, _gramps, _father, _child);
     }
 

--- a/contracts/mocks/governance/GovernorCompatibilityBravoMockUpgradeable.sol
+++ b/contracts/mocks/governance/GovernorCompatibilityBravoMockUpgradeable.sol
@@ -46,17 +46,17 @@ abstract contract GovernorCompatibilityBravoMockUpgradeable is
     }
 
     function propose(
-        address[] memory targets,
-        uint256[] memory values,
+        address[] calldata targets,
+        uint256[] calldata values,
         bytes[] memory calldatas,
-        string memory description
+        string calldata description
     ) public override(IGovernorUpgradeable, GovernorUpgradeable, GovernorCompatibilityBravoUpgradeable) returns (uint256) {
         return super.propose(targets, values, calldatas, description);
     }
 
     function queue(
-        address[] memory targets,
-        uint256[] memory values,
+        address[] calldata targets,
+        uint256[] calldata values,
         bytes[] memory calldatas,
         bytes32 salt
     ) public override(IGovernorTimelockUpgradeable, GovernorTimelockCompoundUpgradeable) returns (uint256) {
@@ -64,8 +64,8 @@ abstract contract GovernorCompatibilityBravoMockUpgradeable is
     }
 
     function execute(
-        address[] memory targets,
-        uint256[] memory values,
+        address[] calldata targets,
+        uint256[] calldata values,
         bytes[] memory calldatas,
         bytes32 salt
     ) public payable override(IGovernorUpgradeable, GovernorUpgradeable) returns (uint256) {
@@ -87,8 +87,8 @@ abstract contract GovernorCompatibilityBravoMockUpgradeable is
     }
 
     function _cancel(
-        address[] memory targets,
-        uint256[] memory values,
+        address[] calldata targets,
+        uint256[] calldata values,
         bytes[] memory calldatas,
         bytes32 salt
     ) internal override(GovernorUpgradeable, GovernorTimelockCompoundUpgradeable) returns (uint256 proposalId) {

--- a/contracts/mocks/governance/GovernorMockUpgradeable.sol
+++ b/contracts/mocks/governance/GovernorMockUpgradeable.sol
@@ -24,10 +24,10 @@ abstract contract GovernorMockUpgradeable is
     }
 
     function propose(
-        address[] memory targets,
-        uint256[] memory values,
+        address[] calldata targets,
+        uint256[] calldata values,
         bytes[] memory calldatas,
-        string memory description
+        string calldata description
     ) public override(GovernorUpgradeable, GovernorProposalThresholdUpgradeable) returns (uint256) {
         return super.propose(targets, values, calldatas, description);
     }

--- a/contracts/mocks/governance/GovernorTimelockCompoundMockUpgradeable.sol
+++ b/contracts/mocks/governance/GovernorTimelockCompoundMockUpgradeable.sol
@@ -52,8 +52,8 @@ abstract contract GovernorTimelockCompoundMockUpgradeable is
     }
 
     function _cancel(
-        address[] memory targets,
-        uint256[] memory values,
+        address[] calldata targets,
+        uint256[] calldata values,
         bytes[] memory calldatas,
         bytes32 salt
     ) internal override(GovernorUpgradeable, GovernorTimelockCompoundUpgradeable) returns (uint256 proposalId) {

--- a/contracts/mocks/governance/GovernorTimelockControlMockUpgradeable.sol
+++ b/contracts/mocks/governance/GovernorTimelockControlMockUpgradeable.sol
@@ -50,9 +50,9 @@ abstract contract GovernorTimelockControlMockUpgradeable is
     }
 
     function _cancel(
-        address[] memory targets,
-        uint256[] memory values,
-        bytes[] memory calldatas,
+        address[] calldata targets,
+        uint256[] calldata values,
+        bytes[] calldata calldatas,
         bytes32 descriptionHash
     ) internal override(GovernorUpgradeable, GovernorTimelockControlUpgradeable) returns (uint256 proposalId) {
         return super._cancel(targets, values, calldatas, descriptionHash);

--- a/contracts/mocks/token/ERC721ReceiverMockUpgradeable.sol
+++ b/contracts/mocks/token/ERC721ReceiverMockUpgradeable.sol
@@ -31,7 +31,7 @@ contract ERC721ReceiverMockUpgradeable is Initializable, IERC721ReceiverUpgradea
         address operator,
         address from,
         uint256 tokenId,
-        bytes memory data
+        bytes calldata data
     ) public override returns (bytes4) {
         if (_error == Error.RevertWithMessage) {
             revert("ERC721ReceiverMock: reverting");

--- a/contracts/proxy/utils/UUPSUpgradeable.sol
+++ b/contracts/proxy/utils/UUPSUpgradeable.sol
@@ -86,7 +86,7 @@ abstract contract UUPSUpgradeable is Initializable, IERC1822ProxiableUpgradeable
      *
      * @custom:oz-upgrades-unsafe-allow-reachable delegatecall
      */
-    function upgradeToAndCall(address newImplementation, bytes memory data) public payable virtual onlyProxy {
+    function upgradeToAndCall(address newImplementation, bytes calldata data) public payable virtual onlyProxy {
         _authorizeUpgrade(newImplementation);
         _upgradeToAndCallUUPS(newImplementation, data, true);
     }

--- a/contracts/token/ERC1155/ERC1155Upgradeable.sol
+++ b/contracts/token/ERC1155/ERC1155Upgradeable.sol
@@ -85,8 +85,8 @@ contract ERC1155Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradea
      * - `accounts` and `ids` must have the same length.
      */
     function balanceOfBatch(
-        address[] memory accounts,
-        uint256[] memory ids
+        address[] calldata accounts,
+        uint256[] calldata ids
     ) public view virtual override returns (uint256[] memory) {
         require(accounts.length == ids.length, "ERC1155: accounts and ids length mismatch");
 
@@ -121,7 +121,7 @@ contract ERC1155Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradea
         address to,
         uint256 id,
         uint256 amount,
-        bytes memory data
+        bytes calldata data
     ) public virtual override {
         require(
             from == _msgSender() || isApprovedForAll(from, _msgSender()),

--- a/contracts/token/ERC1155/extensions/ERC1155BurnableUpgradeable.sol
+++ b/contracts/token/ERC1155/extensions/ERC1155BurnableUpgradeable.sol
@@ -27,7 +27,7 @@ abstract contract ERC1155BurnableUpgradeable is Initializable, ERC1155Upgradeabl
         _burn(account, id, value);
     }
 
-    function burnBatch(address account, uint256[] memory ids, uint256[] memory values) public virtual {
+    function burnBatch(address account, uint256[] calldata ids, uint256[] calldata values) public virtual {
         require(
             account == _msgSender() || isApprovedForAll(account, _msgSender()),
             "ERC1155: caller is not token owner or approved"

--- a/contracts/token/ERC1155/presets/ERC1155PresetMinterPauserUpgradeable.sol
+++ b/contracts/token/ERC1155/presets/ERC1155PresetMinterPauserUpgradeable.sol
@@ -59,7 +59,7 @@ contract ERC1155PresetMinterPauserUpgradeable is Initializable, ContextUpgradeab
      *
      * - the caller must have the `MINTER_ROLE`.
      */
-    function mint(address to, uint256 id, uint256 amount, bytes memory data) public virtual {
+    function mint(address to, uint256 id, uint256 amount, bytes calldata data) public virtual {
         require(hasRole(MINTER_ROLE, _msgSender()), "ERC1155PresetMinterPauser: must have minter role to mint");
 
         _mint(to, id, amount, data);
@@ -68,7 +68,7 @@ contract ERC1155PresetMinterPauserUpgradeable is Initializable, ContextUpgradeab
     /**
      * @dev xref:ROOT:erc1155.adoc#batch-operations[Batched] variant of {mint}.
      */
-    function mintBatch(address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data) public virtual {
+    function mintBatch(address to, uint256[] calldata ids, uint256[] calldata amounts, bytes calldata data) public virtual {
         require(hasRole(MINTER_ROLE, _msgSender()), "ERC1155PresetMinterPauser: must have minter role to mint");
 
         _mintBatch(to, ids, amounts, data);

--- a/contracts/token/ERC1155/presets/ERC1155PresetMinterPauserUpgradeable.sol
+++ b/contracts/token/ERC1155/presets/ERC1155PresetMinterPauserUpgradeable.sol
@@ -27,7 +27,7 @@ import "../../../proxy/utils/Initializable.sol";
  * _Deprecated in favor of https://wizard.openzeppelin.com/[Contracts Wizard]._
  */
 contract ERC1155PresetMinterPauserUpgradeable is Initializable, ContextUpgradeable, AccessControlEnumerableUpgradeable, ERC1155BurnableUpgradeable, ERC1155PausableUpgradeable {
-    function initialize(string memory uri) public virtual initializer {
+    function initialize(string calldata uri) public virtual initializer {
         __ERC1155PresetMinterPauser_init(uri);
     }
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");

--- a/contracts/token/ERC1155/utils/ERC1155HolderUpgradeable.sol
+++ b/contracts/token/ERC1155/utils/ERC1155HolderUpgradeable.sol
@@ -25,7 +25,7 @@ contract ERC1155HolderUpgradeable is Initializable, ERC1155ReceiverUpgradeable {
         address,
         uint256,
         uint256,
-        bytes memory
+        bytes calldata
     ) public virtual override returns (bytes4) {
         return this.onERC1155Received.selector;
     }
@@ -33,9 +33,9 @@ contract ERC1155HolderUpgradeable is Initializable, ERC1155ReceiverUpgradeable {
     function onERC1155BatchReceived(
         address,
         address,
-        uint256[] memory,
-        uint256[] memory,
-        bytes memory
+        uint256[] calldata,
+        uint256[] calldata,
+        bytes calldata
     ) public virtual override returns (bytes4) {
         return this.onERC1155BatchReceived.selector;
     }

--- a/contracts/token/ERC20/presets/ERC20PresetFixedSupplyUpgradeable.sol
+++ b/contracts/token/ERC20/presets/ERC20PresetFixedSupplyUpgradeable.sol
@@ -20,7 +20,7 @@ import "../../../proxy/utils/Initializable.sol";
  * _Deprecated in favor of https://wizard.openzeppelin.com/[Contracts Wizard]._
  */
 contract ERC20PresetFixedSupplyUpgradeable is Initializable, ERC20BurnableUpgradeable {
-    function initialize(string memory name, string memory symbol, uint256 initialSupply, address owner) public virtual initializer {
+    function initialize(string calldata name, string calldata symbol, uint256 initialSupply, address owner) public virtual initializer {
         __ERC20PresetFixedSupply_init(name, symbol, initialSupply, owner);
     }
     /**

--- a/contracts/token/ERC20/presets/ERC20PresetMinterPauserUpgradeable.sol
+++ b/contracts/token/ERC20/presets/ERC20PresetMinterPauserUpgradeable.sol
@@ -27,7 +27,7 @@ import "../../../proxy/utils/Initializable.sol";
  * _Deprecated in favor of https://wizard.openzeppelin.com/[Contracts Wizard]._
  */
 contract ERC20PresetMinterPauserUpgradeable is Initializable, ContextUpgradeable, AccessControlEnumerableUpgradeable, ERC20BurnableUpgradeable, ERC20PausableUpgradeable {
-    function initialize(string memory name, string memory symbol) public virtual initializer {
+    function initialize(string calldata name, string calldata symbol) public virtual initializer {
         __ERC20PresetMinterPauser_init(name, symbol);
     }
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");

--- a/contracts/token/ERC721/ERC721Upgradeable.sol
+++ b/contracts/token/ERC721/ERC721Upgradeable.sol
@@ -169,7 +169,7 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
     /**
      * @dev See {IERC721-safeTransferFrom}.
      */
-    function safeTransferFrom(address from, address to, uint256 tokenId, bytes memory data) public virtual override {
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data) public virtual override {
         require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721: caller is not token owner or approved");
         _safeTransfer(from, to, tokenId, data);
     }

--- a/contracts/token/ERC721/presets/ERC721PresetMinterPauserAutoIdUpgradeable.sol
+++ b/contracts/token/ERC721/presets/ERC721PresetMinterPauserAutoIdUpgradeable.sol
@@ -36,7 +36,7 @@ contract ERC721PresetMinterPauserAutoIdUpgradeable is
     ERC721BurnableUpgradeable,
     ERC721PausableUpgradeable
 {
-    function initialize(string memory name, string memory symbol, string memory baseTokenURI) public virtual initializer {
+    function initialize(string calldata name, string calldata symbol, string calldata baseTokenURI) public virtual initializer {
         __ERC721PresetMinterPauserAutoId_init(name, symbol, baseTokenURI);
     }
     using CountersUpgradeable for CountersUpgradeable.Counter;

--- a/contracts/token/ERC721/utils/ERC721HolderUpgradeable.sol
+++ b/contracts/token/ERC721/utils/ERC721HolderUpgradeable.sol
@@ -23,7 +23,7 @@ contract ERC721HolderUpgradeable is Initializable, IERC721ReceiverUpgradeable {
      *
      * Always returns `IERC721Receiver.onERC721Received.selector`.
      */
-    function onERC721Received(address, address, uint256, bytes memory) public virtual override returns (bytes4) {
+    function onERC721Received(address, address, uint256, bytes calldata) public virtual override returns (bytes4) {
         return this.onERC721Received.selector;
     }
 

--- a/contracts/token/ERC777/ERC777Upgradeable.sol
+++ b/contracts/token/ERC777/ERC777Upgradeable.sol
@@ -128,7 +128,7 @@ contract ERC777Upgradeable is Initializable, ContextUpgradeable, IERC777Upgradea
      *
      * Also emits a {IERC20-Transfer} event for ERC20 compatibility.
      */
-    function send(address recipient, uint256 amount, bytes memory data) public virtual override {
+    function send(address recipient, uint256 amount, bytes calldata data) public virtual override {
         _send(_msgSender(), recipient, amount, data, "", true);
     }
 
@@ -150,7 +150,7 @@ contract ERC777Upgradeable is Initializable, ContextUpgradeable, IERC777Upgradea
      *
      * Also emits a {IERC20-Transfer} event for ERC20 compatibility.
      */
-    function burn(uint256 amount, bytes memory data) public virtual override {
+    function burn(uint256 amount, bytes calldata data) public virtual override {
         _burn(_msgSender(), amount, data, "");
     }
 
@@ -210,8 +210,8 @@ contract ERC777Upgradeable is Initializable, ContextUpgradeable, IERC777Upgradea
         address sender,
         address recipient,
         uint256 amount,
-        bytes memory data,
-        bytes memory operatorData
+        bytes calldata data,
+        bytes calldata operatorData
     ) public virtual override {
         require(isOperatorFor(_msgSender(), sender), "ERC777: caller is not an operator for holder");
         _send(sender, recipient, amount, data, operatorData, true);
@@ -225,8 +225,8 @@ contract ERC777Upgradeable is Initializable, ContextUpgradeable, IERC777Upgradea
     function operatorBurn(
         address account,
         uint256 amount,
-        bytes memory data,
-        bytes memory operatorData
+        bytes calldata data,
+        bytes calldata operatorData
     ) public virtual override {
         require(isOperatorFor(_msgSender(), account), "ERC777: caller is not an operator for holder");
         _burn(account, amount, data, operatorData);

--- a/contracts/token/ERC777/presets/ERC777PresetFixedSupplyUpgradeable.sol
+++ b/contracts/token/ERC777/presets/ERC777PresetFixedSupplyUpgradeable.sol
@@ -15,9 +15,9 @@ import "../../../proxy/utils/Initializable.sol";
  */
 contract ERC777PresetFixedSupplyUpgradeable is Initializable, ERC777Upgradeable {
     function initialize(
-        string memory name,
-        string memory symbol,
-        address[] memory defaultOperators,
+        string calldata name,
+        string calldata symbol,
+        address[] calldata defaultOperators,
         uint256 initialSupply,
         address owner
     ) public virtual initializer {


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Changing the data location of function parameters from memory to calldata can save much gas.
In the following example, test4 saves about 955 units of gas.

```
    function test3(uint256[] memory amounts) public {
        uint256 amount = amounts[0];
    }

    function test4(uint256[] calldata amounts) public {
        uint256 amount = amounts[0];
    }
```

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
