### PR TITLE
move loop invariant variables out from loop to save gas

### DIFF
--- a/contracts/finance/PaymentSplitterUpgradeable.sol
+++ b/contracts/finance/PaymentSplitterUpgradeable.sol
@@ -57,7 +57,8 @@ contract PaymentSplitterUpgradeable is Initializable, ContextUpgradeable {
         require(payees.length == shares_.length, "PaymentSplitter: payees and shares length mismatch");
         require(payees.length > 0, "PaymentSplitter: no payees");
 
-        for (uint256 i = 0; i < payees.length; i++) {
+        uint256 len = payees.length;
+        for (uint256 i = 0; i < len; i++) {
             _addPayee(payees[i], shares_[i]);
         }
     }

--- a/contracts/governance/GovernorUpgradeable.sol
+++ b/contracts/governance/GovernorUpgradeable.sol
@@ -342,7 +342,8 @@ abstract contract GovernorUpgradeable is Initializable, ContextUpgradeable, ERC1
         bytes32 /*descriptionHash*/
     ) internal virtual {
         string memory errorMessage = "Governor: call reverted without message";
-        for (uint256 i = 0; i < targets.length; ++i) {
+        uint256 targetsLen = targets.length;
+        for (uint256 i = 0; i < targetsLen; ++i) {
             (bool success, bytes memory returndata) = targets[i].call{value: values[i]}(calldatas[i]);
             AddressUpgradeable.verifyCallResult(success, returndata, errorMessage);
         }
@@ -359,7 +360,8 @@ abstract contract GovernorUpgradeable is Initializable, ContextUpgradeable, ERC1
         bytes32 /*descriptionHash*/
     ) internal virtual {
         if (_executor() != address(this)) {
-            for (uint256 i = 0; i < targets.length; ++i) {
+            uint256 targetsLen = targets.length;
+            for (uint256 i = 0; i < targetsLen; ++i) {
                 if (targets[i] == address(this)) {
                     _governanceCall.pushBack(keccak256(calldatas[i]));
                 }

--- a/contracts/governance/TimelockControllerUpgradeable.sol
+++ b/contracts/governance/TimelockControllerUpgradeable.sol
@@ -99,13 +99,15 @@ contract TimelockControllerUpgradeable is Initializable, AccessControlUpgradeabl
         }
 
         // register proposers and cancellers
-        for (uint256 i = 0; i < proposers.length; ++i) {
+        uint256 proposersLen = proposers.length;
+        for (uint256 i = 0; i < proposersLen; ++i) {
             _setupRole(PROPOSER_ROLE, proposers[i]);
             _setupRole(CANCELLER_ROLE, proposers[i]);
         }
 
         // register executors
-        for (uint256 i = 0; i < executors.length; ++i) {
+        uint256 executorsLen = executors.length;
+        for (uint256 i = 0; i < executorsLen; ++i) {
             _setupRole(EXECUTOR_ROLE, executors[i]);
         }
 
@@ -260,7 +262,8 @@ contract TimelockControllerUpgradeable is Initializable, AccessControlUpgradeabl
 
         bytes32 id = hashOperationBatch(targets, values, payloads, predecessor, salt);
         _schedule(id, delay);
-        for (uint256 i = 0; i < targets.length; ++i) {
+        uint256 targetsLen = targets.length;
+        for (uint256 i = 0; i < targetsLen; ++i) {
             emit CallScheduled(id, i, targets[i], values[i], payloads[i], predecessor, delay);
         }
         if (salt != bytes32(0)) {
@@ -343,7 +346,8 @@ contract TimelockControllerUpgradeable is Initializable, AccessControlUpgradeabl
         bytes32 id = hashOperationBatch(targets, values, payloads, predecessor, salt);
 
         _beforeCall(id, predecessor);
-        for (uint256 i = 0; i < targets.length; ++i) {
+        uint256 targetsLen = targets.length;
+        for (uint256 i = 0; i < targetsLen; ++i) {
             address target = targets[i];
             uint256 value = values[i];
             bytes calldata payload = payloads[i];

--- a/contracts/governance/compatibility/GovernorCompatibilityBravoUpgradeable.sol
+++ b/contracts/governance/compatibility/GovernorCompatibilityBravoUpgradeable.sol
@@ -125,7 +125,8 @@ abstract contract GovernorCompatibilityBravoUpgradeable is Initializable, IGover
     ) private pure returns (bytes[] memory) {
         bytes[] memory fullcalldatas = new bytes[](calldatas.length);
 
-        for (uint256 i = 0; i < signatures.length; ++i) {
+        uint256 signaturesLen = signatures.length;
+        for (uint256 i = 0; i < signaturesLen; ++i) {
             fullcalldatas[i] = bytes(signatures[i]).length == 0
                 ? calldatas[i]
                 : abi.encodePacked(bytes4(keccak256(bytes(signatures[i]))), calldatas[i]);

--- a/contracts/governance/extensions/GovernorTimelockCompoundUpgradeable.sol
+++ b/contracts/governance/extensions/GovernorTimelockCompoundUpgradeable.sol
@@ -105,7 +105,8 @@ abstract contract GovernorTimelockCompoundUpgradeable is Initializable, IGoverno
 
         uint256 eta = block.timestamp + _timelock.delay();
         _proposalTimelocks[proposalId].timer.setDeadline(eta.toUint64());
-        for (uint256 i = 0; i < targets.length; ++i) {
+        uint256 targetsLen = targets.length;
+        for (uint256 i = 0; i < targetsLen; ++i) {
             require(
                 !_timelock.queuedTransactions(keccak256(abi.encode(targets[i], values[i], "", calldatas[i], eta))),
                 "GovernorTimelockCompound: identical proposal action already queued"
@@ -131,7 +132,8 @@ abstract contract GovernorTimelockCompoundUpgradeable is Initializable, IGoverno
         uint256 eta = proposalEta(proposalId);
         require(eta > 0, "GovernorTimelockCompound: proposal not yet queued");
         AddressUpgradeable.sendValue(payable(_timelock), msg.value);
-        for (uint256 i = 0; i < targets.length; ++i) {
+        uint256 targetsLen = targets.length;
+        for (uint256 i = 0; i < targetsLen; ++i) {
             _timelock.executeTransaction(targets[i], values[i], "", calldatas[i], eta);
         }
     }
@@ -150,7 +152,8 @@ abstract contract GovernorTimelockCompoundUpgradeable is Initializable, IGoverno
 
         uint256 eta = proposalEta(proposalId);
         if (eta > 0) {
-            for (uint256 i = 0; i < targets.length; ++i) {
+            uint256 targetsLen = targets.length;
+            for (uint256 i = 0; i < targetsLen; ++i) {
                 _timelock.cancelTransaction(targets[i], values[i], "", calldatas[i], eta);
             }
             _proposalTimelocks[proposalId].timer.reset();

--- a/contracts/mocks/MulticallTestUpgradeable.sol
+++ b/contracts/mocks/MulticallTestUpgradeable.sol
@@ -16,13 +16,15 @@ contract MulticallTestUpgradeable is Initializable {
         address[] calldata recipients,
         uint256[] calldata amounts
     ) external {
-        bytes[] memory calls = new bytes[](recipients.length);
-        for (uint256 i = 0; i < recipients.length; i++) {
+        uint256 recipientsLen = recipients.length;
+        bytes[] memory calls = new bytes[](recipientsLen);
+        for (uint256 i = 0; i < recipientsLen; i++) {
             calls[i] = abi.encodeWithSignature("transfer(address,uint256)", recipients[i], amounts[i]);
         }
 
         bytes[] memory results = multicallToken.multicall(calls);
-        for (uint256 i = 0; i < results.length; i++) {
+        uint256 resultsLen = results.length;
+        for (uint256 i = 0; i < resultsLen; i++) {
             require(abi.decode(results[i], (bool)));
         }
     }

--- a/contracts/mocks/token/ERC721ConsecutiveEnumerableMockUpgradeable.sol
+++ b/contracts/mocks/token/ERC721ConsecutiveEnumerableMockUpgradeable.sol
@@ -23,7 +23,8 @@ contract ERC721ConsecutiveEnumerableMockUpgradeable is Initializable, ERC721Cons
         address[] memory receivers,
         uint96[] memory amounts
     ) internal onlyInitializing {
-        for (uint256 i = 0; i < receivers.length; ++i) {
+        uint256 receiversLen = receivers.length;
+        for (uint256 i = 0; i < receiversLen; ++i) {
             _mintConsecutive(receivers[i], amounts[i]);
         }
     }

--- a/contracts/mocks/token/ERC721ConsecutiveMockUpgradeable.sol
+++ b/contracts/mocks/token/ERC721ConsecutiveMockUpgradeable.sol
@@ -32,11 +32,13 @@ contract ERC721ConsecutiveMockUpgradeable is Initializable, ERC721ConsecutiveUpg
         address[] memory receivers,
         uint96[] memory amounts
     ) internal onlyInitializing {
-        for (uint256 i = 0; i < delegates.length; ++i) {
+        uint256 delegatesLen = delegates.length;
+        for (uint256 i = 0; i < delegatesLen; ++i) {
             _delegate(delegates[i], delegates[i]);
         }
 
-        for (uint256 i = 0; i < receivers.length; ++i) {
+        uint256 receiversLen = receivers.length;
+        for (uint256 i = 0; i < receiversLen; ++i) {
             _mintConsecutive(receivers[i], amounts[i]);
         }
     }

--- a/contracts/token/ERC1155/ERC1155Upgradeable.sol
+++ b/contracts/token/ERC1155/ERC1155Upgradeable.sol
@@ -88,11 +88,12 @@ contract ERC1155Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradea
         address[] memory accounts,
         uint256[] memory ids
     ) public view virtual override returns (uint256[] memory) {
-        require(accounts.length == ids.length, "ERC1155: accounts and ids length mismatch");
+        uint256 accountsLen = accounts.length;
+        require(accountsLen == ids.length, "ERC1155: accounts and ids length mismatch");
 
-        uint256[] memory batchBalances = new uint256[](accounts.length);
+        uint256[] memory batchBalances = new uint256[](accountsLen);
 
-        for (uint256 i = 0; i < accounts.length; ++i) {
+        for (uint256 i = 0; i < accountsLen; ++i) {
             batchBalances[i] = balanceOf(accounts[i], ids[i]);
         }
 
@@ -205,14 +206,15 @@ contract ERC1155Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradea
         uint256[] memory amounts,
         bytes memory data
     ) internal virtual {
-        require(ids.length == amounts.length, "ERC1155: ids and amounts length mismatch");
+        uint256 idsLen = ids.length;
+        require(idsLen == amounts.length, "ERC1155: ids and amounts length mismatch");
         require(to != address(0), "ERC1155: transfer to the zero address");
 
         address operator = _msgSender();
 
         _beforeTokenTransfer(operator, from, to, ids, amounts, data);
 
-        for (uint256 i = 0; i < ids.length; ++i) {
+        for (uint256 i = 0; i < idsLen; ++i) {
             uint256 id = ids[i];
             uint256 amount = amounts[i];
 
@@ -300,13 +302,14 @@ contract ERC1155Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradea
         bytes memory data
     ) internal virtual {
         require(to != address(0), "ERC1155: mint to the zero address");
-        require(ids.length == amounts.length, "ERC1155: ids and amounts length mismatch");
+        uint256 idsLen = ids.length;
+        require(idsLen == amounts.length, "ERC1155: ids and amounts length mismatch");
 
         address operator = _msgSender();
 
         _beforeTokenTransfer(operator, address(0), to, ids, amounts, data);
 
-        for (uint256 i = 0; i < ids.length; i++) {
+        for (uint256 i = 0; i < idsLen; i++) {
             _balances[ids[i]][to] += amounts[i];
         }
 
@@ -358,13 +361,14 @@ contract ERC1155Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradea
      */
     function _burnBatch(address from, uint256[] memory ids, uint256[] memory amounts) internal virtual {
         require(from != address(0), "ERC1155: burn from the zero address");
-        require(ids.length == amounts.length, "ERC1155: ids and amounts length mismatch");
+        uint256 idsLen = ids.length;
+        require(idsLen == amounts.length, "ERC1155: ids and amounts length mismatch");
 
         address operator = _msgSender();
 
         _beforeTokenTransfer(operator, from, address(0), ids, amounts, "");
 
-        for (uint256 i = 0; i < ids.length; i++) {
+        for (uint256 i = 0; i < idsLen; i++) {
             uint256 id = ids[i];
             uint256 amount = amounts[i];
 

--- a/contracts/token/ERC1155/extensions/ERC1155SupplyUpgradeable.sol
+++ b/contracts/token/ERC1155/extensions/ERC1155SupplyUpgradeable.sol
@@ -50,13 +50,15 @@ abstract contract ERC1155SupplyUpgradeable is Initializable, ERC1155Upgradeable 
         super._beforeTokenTransfer(operator, from, to, ids, amounts, data);
 
         if (from == address(0)) {
-            for (uint256 i = 0; i < ids.length; ++i) {
+            uint256 idsLen = ids.length;
+            for (uint256 i = 0; i < idsLen; ++i) {
                 _totalSupply[ids[i]] += amounts[i];
             }
         }
 
         if (to == address(0)) {
-            for (uint256 i = 0; i < ids.length; ++i) {
+            uint256 idsLen = ids.length;
+            for (uint256 i = 0; i < idsLen; ++i) {
                 uint256 id = ids[i];
                 uint256 amount = amounts[i];
                 uint256 supply = _totalSupply[id];

--- a/contracts/token/ERC777/ERC777Upgradeable.sol
+++ b/contracts/token/ERC777/ERC777Upgradeable.sol
@@ -67,7 +67,8 @@ contract ERC777Upgradeable is Initializable, ContextUpgradeable, IERC777Upgradea
         _symbol = symbol_;
 
         _defaultOperatorsArray = defaultOperators_;
-        for (uint256 i = 0; i < defaultOperators_.length; i++) {
+        uint256 len = defaultOperators_.length;
+        for (uint256 i = 0; i < len; i++) {
             _defaultOperators[defaultOperators_[i]] = true;
         }
 

--- a/contracts/utils/MulticallUpgradeable.sol
+++ b/contracts/utils/MulticallUpgradeable.sol
@@ -22,8 +22,9 @@ abstract contract MulticallUpgradeable is Initializable {
      * @custom:oz-upgrades-unsafe-allow-reachable delegatecall
      */
     function multicall(bytes[] calldata data) external virtual returns (bytes[] memory results) {
-        results = new bytes[](data.length);
-        for (uint256 i = 0; i < data.length; i++) {
+        uint256 len = data.length;
+        results = new bytes[](len);
+        for (uint256 i = 0; i < len; i++) {
             results[i] = _functionDelegateCall(address(this), data[i]);
         }
         return results;

--- a/contracts/utils/cryptography/MerkleProofUpgradeable.sol
+++ b/contracts/utils/cryptography/MerkleProofUpgradeable.sol
@@ -47,7 +47,8 @@ library MerkleProofUpgradeable {
      */
     function processProof(bytes32[] memory proof, bytes32 leaf) internal pure returns (bytes32) {
         bytes32 computedHash = leaf;
-        for (uint256 i = 0; i < proof.length; i++) {
+        uint256 len = proof.length;
+        for (uint256 i = 0; i < len; i++) {
             computedHash = _hashPair(computedHash, proof[i]);
         }
         return computedHash;
@@ -60,7 +61,8 @@ library MerkleProofUpgradeable {
      */
     function processProofCalldata(bytes32[] calldata proof, bytes32 leaf) internal pure returns (bytes32) {
         bytes32 computedHash = leaf;
-        for (uint256 i = 0; i < proof.length; i++) {
+        uint256 len = proof.length;
+        for (uint256 i = 0; i < len; i++) {
             computedHash = _hashPair(computedHash, proof[i]);
         }
         return computedHash;

--- a/contracts/utils/introspection/ERC165CheckerUpgradeable.sol
+++ b/contracts/utils/introspection/ERC165CheckerUpgradeable.sol
@@ -58,7 +58,8 @@ library ERC165CheckerUpgradeable {
         // query support of ERC165 itself
         if (supportsERC165(account)) {
             // query support of each interface in interfaceIds
-            for (uint256 i = 0; i < interfaceIds.length; i++) {
+            uint256 len = interfaceIds.length;
+            for (uint256 i = 0; i < len; i++) {
                 interfaceIdsSupported[i] = supportsERC165InterfaceUnchecked(account, interfaceIds[i]);
             }
         }
@@ -82,7 +83,8 @@ library ERC165CheckerUpgradeable {
         }
 
         // query support of each interface in interfaceIds
-        for (uint256 i = 0; i < interfaceIds.length; i++) {
+        uint256 len = interfaceIds.length;
+        for (uint256 i = 0; i < len; i++) {
             if (!supportsERC165InterfaceUnchecked(account, interfaceIds[i])) {
                 return false;
             }


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Moving loop invariant codes out from loop can save gas.
In the following demo, it can save 765 units of gas when the length of ```arr``` is 100.
```
    function test1(uint256[] calldata arr) public {     
        for(uint256 i = 0; i < arr.length; i++) {
        }
    }

    function test2(uint256[] calldata arr) public {
        uint256 len = arr.length;
        for(uint256 i = 0; i < len; i++) {
        }
    }
```

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
