### PR TITLE
optimize: diff zero address(for mint) with dead address(for burn)

### DIFF
--- a/contracts/token/ERC20/ERC20Upgradeable.sol
+++ b/contracts/token/ERC20/ERC20Upgradeable.sol
@@ -231,7 +231,7 @@ contract ERC20Upgradeable is Initializable, ContextUpgradeable, IERC20Upgradeabl
         _beforeTokenTransfer(from, to, amount);
 
         uint256 fromBalance = _balances[from];
-        require(amount> 0 && fromBalance >= amount, "ERC20: transfer amount exceeds balance");
+        require(amount > 0 && fromBalance >= amount, "ERC20: transfer amount exceeds balance");
         unchecked {
             _balances[from] = fromBalance - amount;
             // Overflow not possible: the sum of all balances is capped by totalSupply, and the sum is preserved by

--- a/contracts/token/ERC20/ERC20Upgradeable.sol
+++ b/contracts/token/ERC20/ERC20Upgradeable.sol
@@ -231,7 +231,7 @@ contract ERC20Upgradeable is Initializable, ContextUpgradeable, IERC20Upgradeabl
         _beforeTokenTransfer(from, to, amount);
 
         uint256 fromBalance = _balances[from];
-        require(amount > 0 && fromBalance >= amount, "ERC20: transfer amount exceeds balance");
+        require(amount> 0 && fromBalance >= amount, "ERC20: transfer amount exceeds balance");
         unchecked {
             _balances[from] = fromBalance - amount;
             // Overflow not possible: the sum of all balances is capped by totalSupply, and the sum is preserved by

--- a/contracts/token/ERC20/ERC20Upgradeable.sol
+++ b/contracts/token/ERC20/ERC20Upgradeable.sol
@@ -37,6 +37,8 @@ import "../../proxy/utils/Initializable.sol";
  * allowances. See {IERC20-approve}.
  */
 contract ERC20Upgradeable is Initializable, ContextUpgradeable, IERC20Upgradeable, IERC20MetadataUpgradeable {
+    address constant private DEAD = 0x000000000000000000000000000000000000dEaD;
+    
     mapping(address => uint256) private _balances;
 
     mapping(address => mapping(address => uint256)) private _allowances;
@@ -280,9 +282,9 @@ contract ERC20Upgradeable is Initializable, ContextUpgradeable, IERC20Upgradeabl
      * - `account` must have at least `amount` tokens.
      */
     function _burn(address account, uint256 amount) internal virtual {
-        require(account != address(0), "ERC20: burn from the zero address");
+        require(account != DEAD, "ERC20: burn from the dead address");
 
-        _beforeTokenTransfer(account, address(0), amount);
+        _beforeTokenTransfer(account, DEAD, amount);
 
         uint256 accountBalance = _balances[account];
         require(accountBalance >= amount, "ERC20: burn amount exceeds balance");
@@ -292,9 +294,9 @@ contract ERC20Upgradeable is Initializable, ContextUpgradeable, IERC20Upgradeabl
             _totalSupply -= amount;
         }
 
-        emit Transfer(account, address(0), amount);
+        emit Transfer(account, DEAD, amount);
 
-        _afterTokenTransfer(account, address(0), amount);
+        _afterTokenTransfer(account, DEAD, amount);
     }
 
     /**

--- a/contracts/token/ERC20/ERC20Upgradeable.sol
+++ b/contracts/token/ERC20/ERC20Upgradeable.sol
@@ -231,7 +231,7 @@ contract ERC20Upgradeable is Initializable, ContextUpgradeable, IERC20Upgradeabl
         _beforeTokenTransfer(from, to, amount);
 
         uint256 fromBalance = _balances[from];
-        require(fromBalance >= amount, "ERC20: transfer amount exceeds balance");
+        require(amount > 0 && fromBalance >= amount, "ERC20: transfer amount exceeds balance");
         unchecked {
             _balances[from] = fromBalance - amount;
             // Overflow not possible: the sum of all balances is capped by totalSupply, and the sum is preserved by


### PR DESCRIPTION
if we use zero address as mint address and burn address, we can't be know how many tokens are burned in scan platform. For users, this part of the information is lost
