### PR TITLE
fix comment of `reinitializer`

### DIFF
--- a/contracts/proxy/utils/Initializable.sol
+++ b/contracts/proxy/utils/Initializable.sol
@@ -140,7 +140,7 @@ abstract contract Initializable {
      * are added through upgrades and that require initialization.
      *
      * When `version` is 1, this modifier is similar to `initializer`, except that functions marked with `reinitializer`
-     * cannot be nested. If one is invoked in the context of another, execution will revert.
+     * cannot be invoked multiple times in the context of a constructor.
      *
      * Note that versions can jump in increments greater than 1; this implies that if multiple reinitializers coexist in
      * a contract, executing them in the right order is up to the developer or operator.


### PR DESCRIPTION
`initializer` modifier can't be nested, either. So it's not a difference.

The comment of `initializer` says:

> 
>      * Similar to `reinitializer(1)`, except that in the context of a constructor an `initializer` may be invoked any
>      * number of times. This behavior in the constructor can be useful during testing and is not expected to be used in
>      * production.


This PR makes the comment of `reinitializer` consistent with that of `initializer`.