### PR TITLE
fix: typos in documentation files

### DIFF
--- a/audits/2017-03.md
+++ b/audits/2017-03.md
@@ -20,7 +20,7 @@ The git commit hash we evaluated is:
 
 # Disclaimer
 
-The audit makes no statements or warrantees about utility of the code, safety of the code, suitability of the business model, regulatory regime for the business model, or any other statements about fitness of the contracts to purpose, or their bugfree status. The audit documentation is for discussion purposes only.
+The audit makes no statements or warranties about utility of the code, safety of the code, suitability of the business model, regulatory regime for the business model, or any other statements about fitness of the contracts to purpose, or their bug-free status. The audit documentation is for discussion purposes only.
 
 # Executive Summary
 
@@ -182,7 +182,7 @@ Just an interface. Note it allows changing an owner address, but not changing th
 
 ### PullPayment
 
-Safe from reentrance attack since ether send is at the end, plus it uses `.send()` rather than `.call.value()`.
+Safe from reentrancy attack since ether send is at the end, plus it uses `.send()` rather than `.call.value()`.
 
 There's an argument to be made that `.call.value()` is a better option *if* you're sure that it will be done after all state updates, since `.send` will fail if the recipient has an expensive fallback function. However, in the context of a function meant to be embedded in other contracts, it's probably better to use `.send`. One possible compromise is to add a function which allows only the owner to send ether via `.call.value`.
 

--- a/test/TESTING.md
+++ b/test/TESTING.md
@@ -1,3 +1,3 @@
 ## Testing
 
-Unit test are critical to OpenZeppelin Contracts. They help ensure code quality and mitigate against security vulnerabilities. The directory structure within the `/test` directory corresponds to the `/contracts` directory.
+Unit tests are critical to OpenZeppelin Contracts. They help ensure code quality and mitigate against security vulnerabilities. The directory structure within the `/test` directory corresponds to the `/contracts` directory.


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `warrantees` to `warranties`
Corrected `bugfree` to `bug-free`
Corrected `reentrance` to `reentrancy`
Corrected `Unit test are` to `Unit tests are`

Please review the changes and let me know if any additional changes are needed.

