### PR TITLE
ERC20PermitUpgradeable - removed unused init_unchained function

### DIFF
--- a/contracts/token/ERC20/extensions/ERC20PermitUpgradeable.sol
+++ b/contracts/token/ERC20/extensions/ERC20PermitUpgradeable.sol
@@ -41,8 +41,6 @@ abstract contract ERC20PermitUpgradeable is Initializable, ERC20Upgradeable, IER
         __EIP712_init_unchained(name, "1");
     }
 
-    function __ERC20Permit_init_unchained(string memory) internal onlyInitializing {}
-
     /// @inheritdoc IERC20Permit
     function permit(
         address owner,


### PR DESCRIPTION
Some project's audit raised the issue of having unused function  __ERC20Permit_init_unchained() with the suggestion to avoid such unreachable code.
