### PR TITLE
Fix dead links in audit files

### DIFF
--- a/audits/2017-03.md
+++ b/audits/2017-03.md
@@ -11,7 +11,7 @@ Zeppelin requested that New Alchemy perform an audit of the contracts in their O
 
 The contracts are hosted at:
 
-https://github.com/OpenZeppelin/zeppelin-solidity
+https://github.com/OpenZeppelin/openzeppelin-contracts
 
 All the contracts in the "contracts" folder are in scope.
 


### PR DESCRIPTION

Updated GitHub repository link** in `audits/2017-03.md` from deprecated `zeppelin-solidity` to current `openzeppelin-contracts`
