### PR TITLE
Fix duplicate word in BridgeMultiTokenUpgradeable documentation

### DIFF
--- a/contracts/crosschain/bridges/abstract/BridgeMultiTokenUpgradeable.sol
+++ b/contracts/crosschain/bridges/abstract/BridgeMultiTokenUpgradeable.sol
@@ -18,7 +18,7 @@ import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.s
  * This base contract is used by the {BridgeERC1155}, which interfaces with legacy ERC-1155 tokens. It is also used by
  * the {ERC1155Crosschain} extension, which embeds the bridge logic directly in the token contract.
  *
- * This base contract implements the crosschain transfer operation though internal functions. It is for the the "child
+ * This base contract implements the crosschain transfer operation though internal functions. It is for the "child
  * contracts" that inherit from this to implement the external interfaces and make this functions accessible.
  */
 abstract contract BridgeMultiTokenUpgradeable is Initializable, ContextUpgradeable, CrosschainLinkedUpgradeable {


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixed a minor typo in the NatSpec documentation for BridgeMultiTokenUpgradeable.sol where the word "the" was duplicated.


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
